### PR TITLE
Fix dependency conflict by downgrading ngx-toastr to v12.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ts-loader": "^9.4.4",
     "css-loader": "^5.1.1",
     "electron": "^7.0.0",
-    "ngx-toastr": "^13.2.1",
+    "ngx-toastr": "^12.1.0",
     "node-sass": "^5.0.0",
     "pug": "^2.0.3",
     "pug-loader": "^2.4.0",


### PR DESCRIPTION
### **PR Type**
Bug fix, Dependencies


___

### **Description**
- Downgraded `ngx-toastr` dependency to version 12.1.0.

- Resolved compatibility issues caused by `ngx-toastr` version 13.2.1.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Downgrade `ngx-toastr` dependency to resolve conflicts</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<li>Downgraded <code>ngx-toastr</code> version from 13.2.1 to 12.1.0.<br> <li> Addressed compatibility issues with the newer version.


</details>


  </td>
  <td><a href="https://github.com/Zeeeepa/tabby-save-output/pull/7/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>